### PR TITLE
Handle longer strings in logs

### DIFF
--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDave.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDave.java
@@ -120,7 +120,7 @@ public class LibDave {
 
             try {
                 logSinkCallback.onLogSink(
-                    severityEnum, NativeUtils.asJavaString(file), line, NativeUtils.asJavaString(message));
+                        severityEnum, NativeUtils.asJavaString(file), line, NativeUtils.asJavaString(message));
             } catch (Throwable t) {
                 log.error("Caught unexpected exception while trying to log message", t);
             }

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/NativeUtils.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/NativeUtils.java
@@ -1,7 +1,6 @@
 package club.minnced.discord.jdave.ffi;
 
 import java.lang.foreign.*;
-import java.nio.charset.StandardCharsets;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -9,8 +8,8 @@ public class NativeUtils {
     @NonNull
     public static String asJavaString(@NonNull MemorySegment nullTerminatedString) {
         return nullTerminatedString
-            .reinterpret(12288) // 12K
-            .getString(0);
+                .reinterpret(12288) // 12K
+                .getString(0);
     }
 
     public static boolean isNull(@Nullable MemorySegment segment) {


### PR DESCRIPTION
When converting a memory segment from libdave to a Java string it seems that sometimes the output is greater than 4096 bytes - in this case it should be fine to assume that the provided memory segment holds a valid null terminated string, so we should be able to read the full segment and convert that to a standard utf8 string.

This change should fix the issue outlined at https://github.com/MinnDevelopment/jdave/issues/17

Please let me know if you require a change to this proposal.

Cheers
