### PR TITLE
Add JPMS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,34 @@ WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers i
 WARNING: Restricted methods will be blocked in a future release unless native access is enabled
 ```
 
-To remove these warnings, you need to either allow these methods through the command line arguments:
+To remove these warnings, you need to allow native access for the module that calls the restricted methods.
+
+### Unnamed modules (classpath)
+
+If you are running jdave on the classpath (no `module-info.java`), use:
 
 ```shell
 java --enable-native-access=ALL-UNNAMED ...
 ```
 
-Or enabling them in your JAR-file manifest:
+Or in your JAR-file manifest:
+
+```
+Enable-Native-Access: ALL-UNNAMED
+```
+
+### Named modules (module path)
+
+If your application uses JPMS modules, specify the jdave module name instead:
 
 ```shell
-Enable-Native-Access: ALL-UNNAMED
+java --enable-native-access=club.minnced.discord.jdave ...
+```
+
+Or in your JAR-file manifest:
+
+```
+Enable-Native-Access: club.minnced.discord.jdave
 ```
 
 ## Why Java 25?

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDave.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDave.java
@@ -62,6 +62,7 @@ public class LibDave {
         }
     }
 
+    @SuppressWarnings("restricted")
     public static void setLogSinkCallback(@NonNull Arena arena, @NonNull LogSinkCallback logSinkCallback) {
         LogSinkCallbackMapper upcallMapper = new LogSinkCallbackMapper(logSinkCallback);
 

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveDecryptorBinding.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveDecryptorBinding.java
@@ -9,7 +9,9 @@ import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import org.jspecify.annotations.NonNull;
 
+@SuppressWarnings("restricted")
 public class LibDaveDecryptorBinding {
+    private LibDaveDecryptorBinding() {}
 
     static final MethodHandle daveDecryptorCreate;
     static final MethodHandle daveDecryptorDestroy;

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveEncryptorBinding.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveEncryptorBinding.java
@@ -8,7 +8,10 @@ import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import org.jspecify.annotations.NonNull;
 
+@SuppressWarnings("restricted")
 public class LibDaveEncryptorBinding {
+    private LibDaveEncryptorBinding() {}
+
     static final MethodHandle daveEncryptorCreate;
     static final MethodHandle daveEncryptorDestroy;
     static final MethodHandle daveEncryptorSetKeyRatchet;

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveKeyRatchetBinding.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveKeyRatchetBinding.java
@@ -8,6 +8,8 @@ import java.lang.invoke.MethodHandle;
 import org.jspecify.annotations.NonNull;
 
 public class LibDaveKeyRatchetBinding {
+    private LibDaveKeyRatchetBinding() {}
+
     private static final MethodHandle destroyKeyRatchet;
 
     static {

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveLookup.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveLookup.java
@@ -7,7 +7,10 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 
+@SuppressWarnings("restricted")
 public class LibDaveLookup {
+    private LibDaveLookup() {}
+
     static final Linker LINKER = Linker.nativeLinker();
     static final SymbolLookup SYMBOL_LOOKUP;
     public static final MemoryLayout C_SIZE;

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveSessionBinding.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/LibDaveSessionBinding.java
@@ -11,7 +11,10 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import org.jspecify.annotations.NonNull;
 
+@SuppressWarnings("restricted")
 public class LibDaveSessionBinding {
+    private LibDaveSessionBinding() {}
+
     static final MethodHandle daveSessionCreate;
     static final MethodHandle daveSessionDestroy;
     static final MethodHandle daveSessionInit;

--- a/api/src/main/java/club/minnced/discord/jdave/ffi/NativeUtils.java
+++ b/api/src/main/java/club/minnced/discord/jdave/ffi/NativeUtils.java
@@ -7,7 +7,10 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public class NativeUtils {
+    private NativeUtils() {}
+
     @NonNull
+    @SuppressWarnings("restricted")
     public static String asJavaString(@NonNull MemorySegment nullTerminatedString) {
         return nullTerminatedString.reinterpret(1024 * 64).getString(0);
     }

--- a/api/src/main/java/club/minnced/discord/jdave/interop/JDaveSessionFactory.java
+++ b/api/src/main/java/club/minnced/discord/jdave/interop/JDaveSessionFactory.java
@@ -6,6 +6,8 @@ import net.dv8tion.jda.api.audio.dave.DaveSessionFactory;
 import org.jspecify.annotations.NonNull;
 
 public class JDaveSessionFactory implements DaveSessionFactory {
+    public JDaveSessionFactory() {}
+
     @NonNull
     @Override
     public DaveSession createDaveSession(@NonNull DaveProtocolCallbacks callbacks, long userId, long channelId) {

--- a/api/src/main/java/club/minnced/discord/jdave/utils/DaveLogger.java
+++ b/api/src/main/java/club/minnced/discord/jdave/utils/DaveLogger.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 public class DaveLogger {
+    private DaveLogger() {}
+
     @SuppressWarnings("LoggerInitializedWithForeignClass")
     public static final Logger log = LoggerFactory.getLogger(LibDave.class);
 

--- a/api/src/main/java/club/minnced/discord/jdave/utils/NativeLibraryLoader.java
+++ b/api/src/main/java/club/minnced/discord/jdave/utils/NativeLibraryLoader.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NativeLibraryLoader {
+    private NativeLibraryLoader() {}
+
     public static final String LIBRARY_PATH_PROPERTY = "jdave.library.path";
 
     private static final Logger log = LoggerFactory.getLogger(NativeLibraryLoader.class);
@@ -41,7 +43,8 @@ public class NativeLibraryLoader {
     public static Path createTemporaryFile() {
         NativeLibrary nativeLibrary = getNativeLibrary();
 
-        try (InputStream library = NativeLibraryLoader.class.getResourceAsStream(nativeLibrary.resourcePath())) {
+        String resourceName = nativeLibrary.resourcePath().substring(1); // strip leading /
+        try (InputStream library = NativeLibraryLoader.class.getResourceAsStream(resourceName)) {
             if (library == null) {
                 throw new LibDaveBindingException(
                         "Could not find resource for current platform. Looked for " + nativeLibrary.resourcePath());
@@ -63,6 +66,7 @@ public class NativeLibraryLoader {
         }
     }
 
+    @SuppressWarnings("restricted")
     @NonNull
     public static SymbolLookup getSymbolLookup() {
         String customLibraryPath = getLibraryPath();
@@ -92,6 +96,7 @@ public class NativeLibraryLoader {
         return new NativeLibrary(os, arch, baseName);
     }
 
+    @SuppressWarnings("restricted")
     @NonNull
     private static SymbolLookup getSymbolLookupFromPath(@NonNull String customLibraryPath) {
         Path path = Path.of(customLibraryPath).toAbsolutePath();

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,7 +1,6 @@
 module club.minnced.discord.jdave {
-    requires java.base;
-    requires transitive net.dv8tion.jda;
-    requires org.jspecify;
+    requires static transitive net.dv8tion.jda;
+    requires static org.jspecify;
     requires org.slf4j;
 
     exports club.minnced.discord.jdave;

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module club.minnced.discord.jdave {
+    requires java.base;
+    requires transitive net.dv8tion.jda;
+    requires org.jspecify;
+    requires org.slf4j;
+
+    exports club.minnced.discord.jdave;
+    exports club.minnced.discord.jdave.ffi;
+    exports club.minnced.discord.jdave.interop;
+    exports club.minnced.discord.jdave.manager;
+    exports club.minnced.discord.jdave.utils;
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,9 @@ subprojects {
     }
 
     configure<JavaPluginExtension> {
-        sourceCompatibility = JavaVersion.VERSION_25
-        targetCompatibility = JavaVersion.VERSION_25
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
 
         withJavadocJar()
         withSourcesJar()
@@ -35,8 +36,7 @@ subprojects {
 
     tasks.withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
-        options.release = 25
 
-        options.compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-options", "-Xlint:-restricted"))
+        options.compilerArgs.addAll(listOf("-Xlint:all", "-Xlint:-options", "-Xlint:-exports", "-Xlint:-requires-transitive-automatic", "-Xlint:-requires-automatic"))
     }
 }


### PR DESCRIPTION
This PR adds a JPMS module, named `club.minnced.discord.jdave`.

While the project could use automatic modules, considering the project is Java 25 it seems reasonable to implement proper module support for the project, and the list of packages is pretty easy to maintain. (JDA can't be modularised because it has a minimum of Java 8, but it has automatic module support.)

The reason I am hoping to add this is because some tooling fails to find the symbols, and it is better to work using module path than class path when using modular projects.