### PR TITLE
Allow users to bring their own libdave

### DIFF
--- a/api/src/main/java/club/minnced/discord/jdave/utils/NativeLibraryLoader.java
+++ b/api/src/main/java/club/minnced/discord/jdave/utils/NativeLibraryLoader.java
@@ -46,8 +46,13 @@ public class NativeLibraryLoader {
 
     @NonNull
     public static SymbolLookup getSymbolLookup() {
-        Path tempFile = createTemporaryFile();
-        return SymbolLookup.libraryLookup(tempFile, Arena.global());
+        String envPath = System.getenv().get("LIBDAVE_PATH");
+        if (envPath != null) {
+            return SymbolLookup.libraryLookup(envPath, Arena.global());
+        } else {
+            Path tempFile = createTemporaryFile();
+            return SymbolLookup.libraryLookup(tempFile, Arena.global());
+        }
     }
 
     @NonNull


### PR DESCRIPTION
The project does currently not work on some Linux distros, such as CentOS Stream, due to the shared libraries requiring a recent glibc version. Also more obscure operating systems, such as FreeBSD are also not supported. This has already been pointed out by [issue #30 30](https://github.com/MinnDevelopment/jdave/issues/30)

This is a fairly simple fix, where one can depend only on club.mincced:jdave-api, and provide the library file separately by specifying a path as `LIBDAVE_PATH=/opt/libdave.so java -jar bot.jar`. 

This also avoids reading a shared library from `/tmp/`, which has some security implications I'm not a fan of. 